### PR TITLE
Bug: Missing Moonphase Icon /moon23.bmp

### DIFF
--- a/esp8266-weather-station-color.ino
+++ b/esp8266-weather-station-color.ino
@@ -185,7 +185,7 @@ void downloadResources() {
     tft.fillRect(0, 120, 240, 40, ILI9341_BLACK);
     webResource.downloadFile("http://www.squix.org/blog/wunderground/mini/" + wundergroundIcons[i] + ".bmp", "/mini/" + wundergroundIcons[i] + ".bmp", _downloadCallback);
   }
-  for (int i = 0; i < 23; i++) {
+  for (int i = 0; i < 24; i++) {
     tft.fillRect(0, 120, 240, 40, ILI9341_BLACK);
     webResource.downloadFile("http://www.squix.org/blog/moonphase_L" + String(i) + ".bmp", "/moon" + String(i) + ".bmp", _downloadCallback);
   }


### PR DESCRIPTION
The Icon for the last Moonphase is missing.
Serial Console shows /moon23.bmp is missing.
Just changed one Line to get the last icon fetched.
It's only a minor thing, cause the icon is completely black and so there is no visible bug on the display... but it fixes the little error in the console ;)