### PR TITLE
Add ROTATE_180 constant that rotates the screen 180 degrees to allow screen to be mounted inverted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 .DS_Store
+.vscode/c_cpp_properties.json
+.vscode/arduino.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 .vscode/c_cpp_properties.json
 .vscode/arduino.json
+build/

--- a/esp8266-weather-station-color.ino
+++ b/esp8266-weather-station-color.ino
@@ -189,6 +189,9 @@ void setup() {
   digitalWrite(TFT_LED, HIGH);    // HIGH to Turn on;
 
   gfx.init();
+#ifdef ROTATE_180
+  gfx.setRotation(2); // Flip the screen 180
+#endif
   gfx.fillBuffer(MINI_BLACK);
   gfx.commit();
 
@@ -823,7 +826,7 @@ void loadPropertiesFromSpiffs() {
     Serial.println("Effective properties now as follows:");
     Serial.println("\tssid: " + WIFI_SSID);
     Serial.println("\tpassword: " + WIFI_PASS);
-    Serial.println("\timezone: " + TIMEZONE);
+    Serial.println("\ttimezone: " + TIMEZONE);
     Serial.println("\tOWM API key: " + OPEN_WEATHER_MAP_API_KEY);
     Serial.println("\tOWM location id: " + OPEN_WEATHER_MAP_LOCATION_ID);
     Serial.println("\tlocation name: " + DISPLAYED_LOCATION_NAME);
@@ -848,6 +851,7 @@ uint8_t changeScreen(TS_Point p, uint8_t screen) {
   // if (p.x <= dividerMiddle)  Serial.print(" right ");  // <= 120
   // Serial.println();
 
+#ifndef ROTATE_180
   if (p.y < dividerTop) {            // top -> change 12/24h style
     IS_STYLE_12HR = !IS_STYLE_12HR;
   } else if (p.y > dividerBottom) {  // bottom -> go to screen 0
@@ -860,5 +864,19 @@ uint8_t changeScreen(TS_Point p, uint8_t screen) {
   } else {                      // right -> next screen
     page = (page + 1) % screenCount;
   }
+#else
+  if (p.y > dividerBottom) {            // top -> change 12/24h style
+    IS_STYLE_12HR = !IS_STYLE_12HR;
+  } else if (p.y < dividerTop) {  // bottom -> go to screen 0
+    page = 0;
+  } else if (p.x < dividerMiddle) {  // left -> previous page
+    if (page == 0) {            // Note type is unsigned
+      page = screenCount;       // Last screen is max -1
+    }
+    page--;
+  } else {                      // right -> next screen
+    page = (page + 1) % screenCount;
+  }
+#endif
   return page;
 }

--- a/settings.h
+++ b/settings.h
@@ -109,6 +109,7 @@ const char MOON_ICONS_SOUTH_WAXING[] = {64, 77, 76, 75, 74, 73, 72, 71, 70, 69, 
 #define TOUCH_CS D3
 #define TOUCH_IRQ  D4
 
+//#define ROTATE_180
 
 /***************************
  * End Settings


### PR DESCRIPTION
…mounting the screen inverted

Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is compliant with the [other contributing guidelines](https://github.com/ThingPulse/esp8266-weather-station-color/blob/master/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] Should this code require changes to documentation I will contribute those to [https://github.com/ThingPulse/docs](https://github.com/ThingPulse/docs).

\<Description of and rationale behind this PR\>
